### PR TITLE
fix ApproximateCreationDateTime

### DIFF
--- a/db/streams.js
+++ b/db/streams.js
@@ -25,7 +25,7 @@ function createStreamRecord(store, table, oldItem, newItem, cb) {
     var record = {
       awsRegion: store.tableDb.awsRegion,
       dynamodb: {
-        ApproximateCreationDateTime: Date.now(),
+        ApproximateCreationDateTime: Math.floor(Date.now() / 1000),
         Keys: {},
         SequenceNumber: key,
         SizeBytes: 0,


### PR DESCRIPTION
Date.now() returns milliseconds which is interpreted incorectly by
boto3. For example boto3 will interprete the ApproximateCreationDateTime as something like `Fri Jan 08 49712 17:18:22`. This crashes boto3 with an error `year is out of range`. We need unix timestamp there (seconds)